### PR TITLE
feat(front): codeEditor 버튼 클릭시 toast 알림 생성

### DIFF
--- a/frontend/src/components/CodeEditor.js
+++ b/frontend/src/components/CodeEditor.js
@@ -8,6 +8,7 @@ import {
   CircularProgressLabel,
   Box,
   Divider,
+  useToast
 } from "@chakra-ui/react";
 import { SearchIcon, DownloadIcon, CopyIcon, RepeatClockIcon } from "@chakra-ui/icons";
 import Editor from "@monaco-editor/react";
@@ -19,6 +20,7 @@ const progress = {
 
 function CodeEditor() {
   const editorRef = useRef(null);
+  const toast = useToast();
   const [value, setValue] = useState("hello");
 
   const inputFile = () => {
@@ -32,10 +34,22 @@ function CodeEditor() {
       editorRef.current.setValue(code);
     };
     fileReader.readAsText(file);
+    toast({
+      title: "코드를 불러왔습니다.",
+      position: "bottom-right",
+      isClosable: true,
+      duration: 1000,
+    });
   };
 
   const resetValue = () => {
     editorRef.current.setValue(value);
+    toast({
+      title: "코드가 초기화 되었습니다.",
+      position: "bottom-right",
+      isClosable: true,
+      duration: 1000,
+    });
   };
 
   const handleEditorDidMount = (editor, monaco) => {
@@ -44,8 +58,21 @@ function CodeEditor() {
 
   const copyValue = () => {
     navigator.clipboard.writeText(editorRef.current?.getValue());
-    // 클립보드 복사 후 toast 출력
-    // console.log(editorRef.current?.getValue());
+    toast({
+      title: "코드가 클립보드에 복사되었습니다.",
+      position: "bottom-right",
+      isClosable: true,
+      duration: 1000,
+    });
+  };
+
+  const saveValue = () => {
+    toast({
+      title: "코드를 저장했습니다.",
+      position: "bottom-right",
+      isClosable: true,
+      duration: 1000,
+    });
   };
 
   return (
@@ -88,6 +115,7 @@ function CodeEditor() {
             background="#718096"
             className="iconBtn"
             aria-label="Download"
+            onClick={saveValue}
             icon={<DownloadIcon />}
           />
         </Box>

--- a/frontend/src/components/CodeEditor.js
+++ b/frontend/src/components/CodeEditor.js
@@ -8,7 +8,7 @@ import {
   CircularProgressLabel,
   Box,
   Divider,
-  useToast
+  useToast,
 } from "@chakra-ui/react";
 import { SearchIcon, DownloadIcon, CopyIcon, RepeatClockIcon } from "@chakra-ui/icons";
 import Editor from "@monaco-editor/react";


### PR DESCRIPTION
## ✏️ 작업 내역

codeEditor 의 코드 불러오기/초기화하기/복사하기/저장하기 할 때 toast로 우측 하단에 알림 띄워주기 구현 

## 💬 비고

작성 코드 저장하는 버튼은 아직 api 연결이 되어있지 않아 버튼 클릭 시 toast 뜨도록 우선 구현해놓았습니다. 

## ✅ 체크 리스트

<!-- 잊지 말고 모든 항목을 체크해주세요. -->

- [x] 적절한 제목으로 수정했나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?
