### PR TITLE
feat(frontend): navigate 기반 라우팅

### DIFF
--- a/frontend/src/components/modals/SelectLecture.js
+++ b/frontend/src/components/modals/SelectLecture.js
@@ -10,8 +10,8 @@ import {
   FormControl,
   Button,
 } from "@chakra-ui/react";
-import axios from "../../utils/axios";
 import { useNavigate } from "react-router-dom";
+import axios from "../../utils/axios";
 
 function SelectLecture({ isOpen, onClose }) {
   const initialRef = React.useRef(null);

--- a/frontend/src/components/modals/SelectLecture.js
+++ b/frontend/src/components/modals/SelectLecture.js
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
-
 import {
   Modal,
   ModalOverlay,
@@ -11,14 +10,15 @@ import {
   FormControl,
   Button,
 } from "@chakra-ui/react";
-import App from "../../pages/App";
 import axios from "../../utils/axios";
+import { useNavigate } from "react-router-dom";
 
 function SelectLecture({ isOpen, onClose }) {
   const initialRef = React.useRef(null);
   const finalRef = React.useRef(null);
   const [lecture, setLecture] = useState([]);
   const [lecID, setSelected] = useState("");
+  const navigate = useNavigate();
 
   const handleSelect = (e) => {
     setSelected(e.target.value);
@@ -41,7 +41,7 @@ function SelectLecture({ isOpen, onClose }) {
       .post(`/lectures/${lecID}/enroll/`)
       .then((response) => {
         if (response.status === 200) {
-          // console.log("성공"); app 페이지로 연결
+          navigate(`/test/${lecID}`);
         }
       })
       .catch((error) => null);

--- a/frontend/src/pages/App.js
+++ b/frontend/src/pages/App.js
@@ -29,7 +29,6 @@ function App() {
   };
 
   useEffect(() => {
-    login();
     getLecture();
   }, []);
 

--- a/frontend/src/pages/App.js
+++ b/frontend/src/pages/App.js
@@ -9,12 +9,12 @@ import CodeEditor from "../components/CodeEditor";
 import Terminal from "../components/Terminial";
 
 function App() {
-  const selectedLecture = 1;
+  const selectedLecture = 1; // 이부분 링크주소에서 변수값 가져와야함
   const [problem, setProblem] = useState({});
   const [lecture, setLecture] = useState({});
   const [loading, setLoading] = useState(true);
 
-  const userName = "홍길동"; // 로그인 정보 필요
+  const userName = "홍길동"; // 로그인 유저 이름 가져와야함
 
   const getProblem = async (problemId) => {
     const response = await axios.get(`problems/${problemId}/`, {});
@@ -26,11 +26,6 @@ function App() {
     const response = await axios.get(`lectures/${selectedLecture}/`, {});
     setLecture(response.data);
     // getProblem(response.data.problems[0].id);
-  };
-
-  // 임시 로그인 함수
-  const login = () => {
-    axios.post("login/", { student_id: 1234, password: "12345" });
   };
 
   useEffect(() => {


### PR DESCRIPTION
## ✏️ 작업 내역

<!-- 여기에 작업한 내용을 간략하게 작성해주세요. -->
(완성)
강의 enroll 성공시 (200번대) 해당 lecture id 기반 라우팅 성공
ex) 강의 2번 선택후 등록 시 localhost:3000/test/2 로 이동
따라서 App.js 내 임시 로그인함수 삭제

(미완성)
App.js내에서 링크에 있는 강의 id값을 가져와서 get lectures/:id 호출해야되는데 아직 고정 변수로 가져옴 
-> selectedLecture 변수 값 현재 2로 되어 있는데 이걸 :id로 바꿔주면됨

## 💬 비고

<!-- 여기에 참고 사항을 적어주세요. 다른 사람이 참고해야 하는 내용을 자유로운 형식으로 적을 수 있습니다. -->

## ✅ 체크 리스트

<!-- 잊지 말고 모든 항목을 체크해주세요. -->

- [x] 적절한 제목으로 수정했나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?
