### PR TITLE
feat(front): 코드 에러 라인 하이라이트 & 종료 갱신 & 제출 alert

### DIFF
--- a/frontend/src/components/CodeEditor.js
+++ b/frontend/src/components/CodeEditor.js
@@ -257,6 +257,7 @@ function CodeEditor({
           minimap: {
             enabled: false,
           },
+          glyphMargin: true,
         }}
         beforeMount={(monaco) => {
           monaco.editor.defineTheme("my-theme", {
@@ -269,7 +270,11 @@ function CodeEditor({
         onMount={handleEditorDidMount}
         onChange={onChangeEditor}
       />
-      <input type="hidden" id="hiddenCodeValue" value={skeletonCode} />
+      <input
+        type="hidden"
+        id="hiddenCodeValue"
+        value={!editorRef.current ? skeletonCode : editorRef.current.getValue()}
+      />
       {isOpenDiff ? (
         <CodeDiffWindow original={submittedCode} modified={answerCode} closeDiff={closeDiff} />
       ) : null}

--- a/frontend/src/components/CodeEditor.js
+++ b/frontend/src/components/CodeEditor.js
@@ -1,6 +1,6 @@
 import "../styles/editor.css";
 import PropTypes from "prop-types";
-import React, { useRef, useState } from "react";
+import React, { useRef, useState, useEffect } from "react";
 import {
   Box,
   Button,
@@ -9,11 +9,10 @@ import {
   Divider,
   IconButton,
   Select,
-  useToast,
 } from "@chakra-ui/react";
 import { CopyIcon, DownloadIcon, RepeatClockIcon, ArrowUpIcon } from "@chakra-ui/icons";
 import FileSaver from "file-saver";
-import Editor, { DiffEditor } from "@monaco-editor/react";
+import Editor from "@monaco-editor/react";
 import axios from "../utils/axios";
 import CodeDiffWindow from "./CodeDiffWindow";
 import { formatEpochTime } from "../utils/dateUtil";
@@ -24,15 +23,28 @@ const progress = {
   height: "32px",
 };
 
-function CodeEditor({ storageCapacity, problem, setProblem, skeletonCode, closeDiff, isOpenDiff }) {
+function CodeEditor({
+  storageCapacity,
+  problem,
+  setProblem,
+  skeletonCode,
+  closeDiff,
+  isOpenDiff,
+  errorInfo,
+  submittedCode,
+  answerCode,
+}) {
   const fileInput = useRef();
   const editorRef = useRef(null);
+  const monacoRef = useRef(null);
   const selectRef = useRef(null);
   const toast = useMyToast();
   const [storageNum, setStorageNum] = useState(-1);
+  const [decorations, setDecorations] = useState([]);
 
   const handleEditorDidMount = (editor, monaco) => {
     editorRef.current = editor;
+    monacoRef.current = monaco;
   };
   const inputFile = () => {
     fileInput.current.value = "";
@@ -124,6 +136,29 @@ function CodeEditor({ storageCapacity, problem, setProblem, skeletonCode, closeD
   const onChangeEditor = () => {
     document.getElementById("hiddenCodeValue").value = editorRef.current.getValue();
   };
+
+  const showErrorLine = (errorinfo) => {
+    if (errorInfo.error !== "") {
+      const decoration = editorRef.current.deltaDecorations(decorations, [
+        {
+          range: new monacoRef.current.Range(errorinfo.error_line, 1, errorinfo.error_line, 1),
+          options: {
+            className: "errorLine",
+            glyphMarginClassName: "errorMark",
+            isWholeLine: true,
+            glyphMarginHoverMessage: { value: errorinfo.error },
+          },
+        },
+      ]);
+      setDecorations([...decorations, decoration]);
+    }
+  };
+
+  useEffect(() => {
+    if (errorInfo !== null) {
+      showErrorLine(errorInfo);
+    }
+  }, [errorInfo]);
 
   return (
     <Box className="container">
@@ -236,11 +271,7 @@ function CodeEditor({ storageCapacity, problem, setProblem, skeletonCode, closeD
       />
       <input type="hidden" id="hiddenCodeValue" value={skeletonCode} />
       {isOpenDiff ? (
-        <CodeDiffWindow
-          original={editorRef.current?.getValue()}
-          modified="#answer code" // 나중에 정답 코드 넣어야 함
-          closeDiff={closeDiff}
-        />
+        <CodeDiffWindow original={submittedCode} modified={answerCode} closeDiff={closeDiff} />
       ) : null}
     </Box>
   );
@@ -262,6 +293,19 @@ CodeEditor.propTypes = {
   skeletonCode: PropTypes.string.isRequired,
   closeDiff: PropTypes.func.isRequired,
   isOpenDiff: PropTypes.bool.isRequired,
+  errorInfo: PropTypes.shape({
+    error: PropTypes.string,
+    error_line: PropTypes.number,
+  }),
+  submittedCode: PropTypes.string.isRequired,
+  answerCode: PropTypes.string.isRequired,
+};
+
+CodeEditor.defaultProps = {
+  errorInfo: PropTypes.shape({
+    error: "",
+    error_line: 0,
+  }),
 };
 
 export default CodeEditor;

--- a/frontend/src/components/Nav.js
+++ b/frontend/src/components/Nav.js
@@ -43,31 +43,44 @@ function Nav({
     onChangeProblem(event.target.value);
   };
 
-  function UnixTimestamp() {
-    if (!isTestEnded) {
-      const currentTime = Math.floor(new Date().getTime() / 1000);
-      const remainTime = deadline ? deadline - currentTime : 0;
-      const date = new Date(remainTime * 1000);
-      const day = Math.floor(remainTime / 60 / 60 / 24);
-      const hour = date.getHours();
-      const minute = date.getMinutes();
-      const second = date.getSeconds();
-      setRemainText(`${day}일 ${hour}시간 ${minute}분 ${second}초`);
-    }
-  }
-
   const endTest = async () => {
+    setIsTestEnded(true);
     try {
       await axios.post(`lectures/${lectureId}/end/`);
       // 종료 처리
-      setIsTestEnded(true);
     } catch (e) {
+      console.log(e);
       toast({
         title: "종료에 실패했습니다.",
         status: "error",
       });
     }
   };
+
+  function UnixTimestamp() {
+    if (!isTestEnded) {
+      const currentTime = Math.floor(new Date().getTime() / 1000);
+      // deadline이랑 설정한 시간이랑 9시간이 차이나서...
+      let remainTime = deadline ? deadline - currentTime + 9 * 60 * 60 : 0;
+      if (remainTime > 0) {
+        const day = Math.floor(remainTime / 60 / 60 / 24);
+        remainTime -= day * 60 * 60 * 24;
+        const hour = Math.floor(remainTime / 60 / 60);
+        remainTime -= hour * 60 * 60;
+        const minute = Math.floor(remainTime / 60);
+        remainTime -= minute * 60;
+        const second = remainTime;
+
+        setRemainText(`${day}일 ${hour}시간 ${minute}분 ${second}초`);
+      } else {
+        clearInterval(interval.current);
+        setRemainText("시험 종료");
+        // endTest();
+        // getLastSumbitResult(); // 마지막에 제출한걸로 결과 보여줌
+        // setIsTestEnded(true);
+      }
+    }
+  }
 
   useEffect(() => {
     interval.current = setInterval(() => {

--- a/frontend/src/components/Nav.js
+++ b/frontend/src/components/Nav.js
@@ -49,7 +49,6 @@ function Nav({
       await axios.post(`lectures/${lectureId}/end/`);
       // 종료 처리
     } catch (e) {
-      console.log(e);
       toast({
         title: "종료에 실패했습니다.",
         status: "error",

--- a/frontend/src/components/SubmitResult.js
+++ b/frontend/src/components/SubmitResult.js
@@ -8,11 +8,13 @@ import {
   AccordionPanel,
   AccordionIcon,
 } from "@chakra-ui/react";
+import PropTypes from "prop-types";
+import { useEffect } from "react";
 import Graph from "./Graph";
 import SubmitTab from "./SubmitTab";
 import DummySubmissions from "../dummyFiles/DummySubmissions.json";
 
-function Submit() {
+function SubmitResult({ submitResult, setAnswerCode }) {
   const { plagiarism } = DummySubmissions.analysis;
   const { explanation } = DummySubmissions.analysis;
   const results = DummySubmissions.result;
@@ -47,6 +49,10 @@ function Submit() {
     }
     return (score * 100) / results.length;
   };
+
+  useEffect(() => {
+    setAnswerCode(submitResult.problem.answer_code);
+  }, [results]);
 
   return (
     <Box className="submit_container">
@@ -126,4 +132,57 @@ function Submit() {
   );
 }
 
-export default Submit;
+SubmitResult.propTypes = {
+  submitResult: PropTypes.shape({
+    id: PropTypes.number.isRequired,
+    created_at: PropTypes.number.isRequired,
+    problem: PropTypes.shape({
+      id: PropTypes.number.isRequired,
+      name: PropTypes.string.isRequired,
+      explanation: PropTypes.string.isRequired,
+      reference: PropTypes.string.isRequired,
+      testcases: PropTypes.arrayOf(
+        PropTypes.shape({
+          input: PropTypes.string,
+          output: PropTypes.string,
+          is_hidden: PropTypes.bool.isRequired,
+        })
+      ).isRequired,
+      skeleton_code: PropTypes.string.isRequired,
+      answer_code: PropTypes.string.isRequired,
+      related_content: PropTypes.string.isRequired,
+      lecture: PropTypes.number.isRequired,
+    }).isRequired,
+    code: PropTypes.string.isRequired,
+    state: PropTypes.number.isRequired,
+    result: PropTypes.arrayOf(
+      PropTypes.shape({
+        input: PropTypes.string,
+        output: PropTypes.string,
+        user_output: PropTypes.string,
+        is_passed: PropTypes.bool.isRequired,
+      })
+    ).isRequired,
+    analysis: PropTypes.shape({
+      plagiarism: PropTypes.number.isRequired,
+      efficiency: PropTypes.shape({
+        loc: PropTypes.number.isRequired,
+        halstead: PropTypes.number.isRequired,
+        data_flow: PropTypes.number.isRequired,
+        control_flow: PropTypes.number.isRequired,
+      }).isRequired,
+      readability: PropTypes.shape({
+        mypy: PropTypes.arrayOf(PropTypes.string).isRequired,
+        pylint: PropTypes.arrayOf(PropTypes.string).isRequired,
+        eradicate: PropTypes.arrayOf(PropTypes.string).isRequired,
+        radon: PropTypes.arrayOf(PropTypes.string).isRequired,
+        pycodestyle: PropTypes.arrayOf(PropTypes.string).isRequired,
+      }).isRequired,
+      explanation: PropTypes.bool.isRequired,
+    }).isRequired,
+    user: PropTypes.number.isRequired,
+  }).isRequired,
+  setAnswerCode: PropTypes.func.isRequired,
+};
+
+export default SubmitResult;

--- a/frontend/src/components/modals/RunCode.js
+++ b/frontend/src/components/modals/RunCode.js
@@ -14,7 +14,7 @@ import {
 
 import axios from "../../utils/axios";
 
-function RunCode({ isOpen, onClose }) {
+function RunCode({ isOpen, onClose, setErrorInfo }) {
   const initialRef = React.useRef(null);
   const toast = useToast();
 
@@ -83,6 +83,7 @@ function RunCode({ isOpen, onClose }) {
           } else if (response.data.error != null) {
             setTerminal("실행 실패", "yellow");
             setTerminal(response.data.error);
+            setErrorInfo(response.data);
           }
         }
       })
@@ -121,6 +122,7 @@ function RunCode({ isOpen, onClose }) {
 RunCode.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
+  setErrorInfo: PropTypes.func.isRequired,
 };
 
 export default RunCode;

--- a/frontend/src/components/modals/SubmitAlert.js
+++ b/frontend/src/components/modals/SubmitAlert.js
@@ -1,0 +1,61 @@
+import React from "react";
+import PropTypes from "prop-types";
+import {
+  AlertDialog,
+  AlertDialogOverlay,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogBody,
+  AlertDialogFooter,
+  Button,
+} from "@chakra-ui/react";
+
+function SubmitAlert({ isOpen, onClose, submissionCount, capacity, submit }) {
+  const initialRef = React.useRef(null);
+
+  return (
+    <AlertDialog
+      size="md"
+      initialFocusRef={initialRef}
+      isOpen={isOpen}
+      onClose={onClose}
+      isCentered
+    >
+      <AlertDialogOverlay />
+      <AlertDialogContent backgroundColor="#1A202C">
+        <AlertDialogHeader fontSize="lg" fontWeight="bold" color="white">
+          제출하시겠습니까?
+        </AlertDialogHeader>
+        <AlertDialogBody pb={6} color="white">
+          제출 횟수 {submissionCount}/{capacity}
+        </AlertDialogBody>
+
+        <AlertDialogFooter>
+          <Button onClick={onClose} marginRight="8px">
+            취소
+          </Button>
+          <Button
+            colorScheme="blue"
+            ml={1}
+            onClick={async () => {
+              await submit();
+              onClose();
+            }}
+          >
+            제출
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
+SubmitAlert.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  submissionCount: PropTypes.number.isRequired,
+  capacity: PropTypes.number.isRequired,
+  submit: PropTypes.func.isRequired,
+};
+
+export default SubmitAlert;

--- a/frontend/src/styles/editor.css
+++ b/frontend/src/styles/editor.css
@@ -53,3 +53,11 @@
     background: #38A169;
     color: #FFFFFF;
 } */
+
+.errorLine {
+  background-color: rgb(107, 67, 67);
+}
+
+.errorMark {
+  background-color: red;
+}


### PR DESCRIPTION
## ✏️ 작업 내역

1. 실행 → 에러 발생 시 에러 라인에 하이라이트 + 에러 메세지
2. alert dialog로 제출 확인 받는 처리 (현재 제출 횟수 + 멘트)
3. 제출 API 연결
4. 제출 횟수 마감시 종료 페이지로 갱신 처리
5. 타이머 끝나면 종료 갱신 + 타이머 중지 및 “시험 종료” 텍스트로 대체

## 💬 비고

제출 결과 받아오는 게 필요해서 제출 get도 조금 해놨습니다(제출 결과 다 적용하는 것도 할 수 있을 거 같은데 겹칠까봐 일단 안올려놨어요)
제출 하자마자 결과 get 해올 때 시간이 좀 걸려서 제출 버튼에 loading 추가했습니다
왜인지 deadline이 관리자 페이지에서 설정해둔 시간보다 9시간 빨라서 일단 9시간 더했습니다ㅜ
에러 메세지는 마우스 hover하면 보입니다

## ✅ 체크 리스트

<!-- 잊지 말고 모든 항목을 체크해주세요. -->

- [x] 적절한 제목으로 수정했나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?
